### PR TITLE
Move user command node api to arbiter

### DIFF
--- a/chamge/arbiter.h
+++ b/chamge/arbiter.h
@@ -39,12 +39,17 @@ struct _ChamgeArbiterClass
   /* methods */
   void  (* approve)                     (ChamgeArbiter *self,
                                          const gchar   *uid);
+  ChamgeReturn (* user_command)         (ChamgeArbiter *self,
+                                         const gchar   *cmd,
+                                         char         **out,
+                                         GError       **error);
 
   /* signals */
   void  (* enrolled)                    (ChamgeArbiter *self,
                                          const gchar   *uid);
   void  (* delisted)                    (ChamgeArbiter *self,
                                          const gchar   *uid);
+
 };
 
 CHAMGE_API_EXPORT
@@ -53,6 +58,12 @@ ChamgeArbiter*  chamge_arbiter_new                      (const gchar   *uid);
 CHAMGE_API_EXPORT
 ChamgeArbiter*  chamge_arbiter_new_full                 (const gchar   *uid,
                                                          ChamgeBackend  bakend);
+
+CHAMGE_API_EXPORT
+ChamgeReturn chamge_arbiter_user_command                (ChamgeArbiter    *self,
+                                                         const gchar   *cmd,
+                                                         gchar        **out,
+                                                         GError       **error);
 
 G_END_DECLS
 

--- a/chamge/node.c
+++ b/chamge/node.c
@@ -89,13 +89,6 @@ chamge_node_get_uid_default (ChamgeNode * self)
   return g_strdup (priv->uid);
 }
 
-static ChamgeReturn
-chamge_node_user_command_default (ChamgeNode * self, const gchar * user_data,
-    gchar ** out, GError ** error)
-{
-  return CHAMGE_RETURN_OK;
-}
-
 static void
 chamge_node_dispose (GObject * object)
 {
@@ -365,21 +358,4 @@ chamge_node_get_uid (ChamgeNode * self, gchar ** uid)
     ret = CHAMGE_RETURN_FAIL;
 
   return ret;
-}
-
-ChamgeReturn
-chamge_node_user_command (ChamgeNode * self, const gchar * cmd, gchar ** out,
-    GError ** error)
-{
-  ChamgeNodeClass *klass;
-  ChamgeReturn ret = CHAMGE_RETURN_OK;
-  ChamgeNodePrivate *priv = chamge_node_get_instance_private (self);
-  g_autoptr (GMutexLocker) locker = NULL;
-
-  g_return_val_if_fail (CHAMGE_IS_NODE (self), CHAMGE_RETURN_FAIL);
-
-  klass = CHAMGE_NODE_GET_CLASS (self);
-  g_return_val_if_fail (klass->user_command != NULL, CHAMGE_RETURN_FAIL);
-
-  return klass->user_command (self, cmd, out, error);
 }

--- a/chamge/node.h
+++ b/chamge/node.h
@@ -54,7 +54,6 @@ struct _ChamgeNodeClass
   ChamgeReturn (* deactivate)           (ChamgeNode *self);
 
   gchar *      (* get_uid)              (ChamgeNode *self);
-  ChamgeReturn (* user_command)         (ChamgeNode *self, const gchar* cmd, gchar **out, GError ** error);
 };
 
 CHAMGE_API_EXPORT
@@ -69,11 +68,7 @@ ChamgeReturn chamge_node_activate       (ChamgeNode *self);
 CHAMGE_API_EXPORT
 ChamgeReturn chamge_node_deactivate     (ChamgeNode *self);
 
-CHAMGE_API_EXPORT
 ChamgeReturn chamge_node_get_uid        (ChamgeNode *self, gchar ** uid);
-
-CHAMGE_API_EXPORT
-ChamgeReturn chamge_node_user_command   (ChamgeNode *self, const gchar *cmd, gchar **out, GError ** error);
 
 G_END_DECLS
 


### PR DESCRIPTION
Due to edge and hub need get-uid api and arbiter only use user_command api, I amd going to get rid those apis from node.