### PR TITLE
ci: add deb packaging for ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 jobs:
-- job: Ubuntu1804
+- job: BuildTest
   displayName: 'Ubuntu 18.04'
   pool: 'Ubuntu1804'
   steps:
@@ -17,3 +17,21 @@ jobs:
   - bash: |
       ninja -C build 
     displayName: 'Ninja build'
+
+- job: BuildPackageUbuntu1804
+  dependsOn: BuildTest
+  displayName: "Packaging for Ubuntu 18.04"
+  pool: 'HwangsaeulUbuntu1804'
+  variables: 
+    ubuntu_version: '1804'
+  steps:
+  - template: ci/debianize-steps.yml
+
+- job: BuildPackageUbuntu1604
+  dependsOn: BuildTest
+  displayName: "Packaging for Ubuntu 16.04"
+  pool: 'HwangsaeulUbuntu1604'
+  variables: 
+    ubuntu_version: '1604'
+  steps:
+  - template: ci/debianize-steps.yml

--- a/ci/debianize-steps.yml
+++ b/ci/debianize-steps.yml
@@ -1,0 +1,20 @@
+steps:
+- bash: |
+    DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc
+  displayName: 'Run dpkg-build'
+
+- bash: |
+    mkdir -p $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    cp ../*.buildinfo $(Build.ArtifactStagingDirectory)/$(ubuntu_version) | true
+    cp ../*.tar.* $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    cp ../*.changes $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    cp ../*.dsc $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    cp ../*.deb $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    cp ../*.ddeb $(Build.ArtifactStagingDirectory)/$(ubuntu_version) | true
+  condition: not(canceled())
+  displayName: 'Copy artifacts'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)/$(ubuntu_version)
+    artifactName: DebianizePackages.$(ubuntu_version)


### PR DESCRIPTION
~~In case of Ubuntu 16.04, `continueOnError` is enabled due to missing features of old meson version. That should be fixed in a separated commit.~~

Jakub fixed it.