### PR TITLE
Add examples

### DIFF
--- a/chamge/edge.c
+++ b/chamge/edge.c
@@ -218,7 +218,6 @@ chamge_edge_class_init (ChamgeEdgeClass * klass)
 static void
 chamge_edge_init (ChamgeEdge * self)
 {
-  ChamgeEdgePrivate *priv = chamge_edge_get_instance_private (self);
 }
 
 ChamgeEdge *
@@ -240,7 +239,6 @@ chamge_edge_request_target_uri (ChamgeEdge * self, GError ** error)
   ChamgeEdgeClass *klass;
   ChamgeNodeState state;
   g_autofree gchar *target_uri = NULL;
-  ChamgeEdgePrivate *priv = chamge_edge_get_instance_private (self);
 
   g_return_val_if_fail (CHAMGE_IS_EDGE (self), NULL);
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);

--- a/chamge/node.c
+++ b/chamge/node.c
@@ -190,6 +190,7 @@ chamge_node_class_init (ChamgeNodeClass * klass)
   klass->activate = chamge_node_activate_default;
   klass->deactivate = chamge_node_deactivate_default;
   klass->get_uid = chamge_node_get_uid_default;
+  klass->user_command = chamge_node_user_command_default;
 }
 
 static void
@@ -374,7 +375,6 @@ chamge_node_user_command (ChamgeNode * self, const gchar * cmd, gchar ** out,
 {
   ChamgeNodeClass *klass;
   ChamgeReturn ret = CHAMGE_RETURN_OK;
-  ChamgeNodePrivate *priv = chamge_node_get_instance_private (self);
   g_autoptr (GMutexLocker) locker = NULL;
 
   g_return_val_if_fail (CHAMGE_IS_NODE (self), CHAMGE_RETURN_FAIL);
@@ -382,5 +382,9 @@ chamge_node_user_command (ChamgeNode * self, const gchar * cmd, gchar ** out,
   klass = CHAMGE_NODE_GET_CLASS (self);
   g_return_val_if_fail (klass->user_command != NULL, CHAMGE_RETURN_FAIL);
 
-  return klass->user_command (self, cmd, out, error);
+  ret = klass->user_command (self, cmd, out, error);
+  if (ret == CHAMGE_RETURN_FAIL)
+    g_debug ("error in user command: %s", *error ? (*error)->message : "NULL");
+
+  return ret;
 }

--- a/examples/arbiter-dummy.c
+++ b/examples/arbiter-dummy.c
@@ -1,0 +1,345 @@
+/**
+ *  tests/test-arbiter
+ *
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Heekyoung Seo <hkseo@sk.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <chamge/chamge.h>
+
+#include <poll.h>
+#include <stdio.h>
+#include <termios.h>
+#include <unistd.h>
+#include <execinfo.h>
+
+#include <glib.h>
+
+#define DEFAULT_ARBITER_UID     "arbiter-987-123"
+#define DEFAULT_BACKEND         CHAMGE_BACKEND_AMQP
+
+typedef struct _ArbiterContext
+{
+  ChamgeArbiter *arbiter;
+  GMainLoop *loop;
+  GThread *user_input_thread;
+
+  GList *edges;
+  GList *hubs;
+
+  struct termios term_properties;
+} ArbiterContext;
+
+static struct termios orig_term_properties;
+typedef void (*sig_handler_t) (int);
+static sig_handler_t signal_register[32];
+
+static void
+user_input_exit ()
+{
+  printf ("[DUMMY] restore tty setting at exit\n");
+  tcsetattr (STDIN_FILENO, TCSANOW, &orig_term_properties);
+}
+
+static void
+signal_handler (int sig)
+{
+  void *array[10];
+  size_t size;
+
+  printf ("signal %d. org %p. restore tty\n", sig, signal_register[sig]);
+  user_input_exit ();
+
+  // get void*'s for all entries on the stack
+  size = backtrace (array, 10);
+
+  // print out all the frames to stderr
+  fprintf (stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd (array, size, STDERR_FILENO);
+
+  exit (128 + sig);
+}
+
+static int
+user_input_init ()
+{
+  struct termios term_properties;
+
+  if (!isatty (STDIN_FILENO))
+    return 0;
+
+  tcgetattr (STDIN_FILENO, &term_properties);
+  orig_term_properties = term_properties;
+
+  atexit (user_input_exit);
+  signal_register[SIGHUP] = signal (SIGHUP, signal_handler);
+  signal_register[SIGINT] = signal (SIGINT, signal_handler);
+  signal_register[SIGABRT] = signal (SIGABRT, signal_handler);
+  signal_register[SIGFPE] = signal (SIGFPE, signal_handler);
+  signal_register[SIGKILL] = signal (SIGKILL, signal_handler);
+  signal_register[SIGSEGV] = signal (SIGSEGV, signal_handler);
+
+  term_properties.c_lflag &= ~(ICANON | ECHO | ECHOE);
+  term_properties.c_cc[VMIN] = 1;
+  tcsetattr (STDIN_FILENO, TCSANOW, &term_properties);
+
+  return 0;
+}
+
+static int
+user_input_get ()
+{
+  int ret;
+  char buf[1];
+
+  if (!isatty (STDIN_FILENO)) {
+    sleep (5);
+    return 0;
+  }
+
+  ret = read (STDIN_FILENO, buf, 1);
+  if (ret != 1)
+    return 0;
+  return buf[0];
+}
+
+static gpointer
+do_user_command (gpointer data)
+{
+  int user_input = 0;
+  gboolean quit = FALSE;
+  ChamgeReturn ret = CHAMGE_RETURN_OK;
+  ArbiterContext *context = (ArbiterContext *) data;
+
+  user_input_init (context);
+
+  while (!quit) {
+    printf
+        ("[DUMMY] ==> wait for key input to send pre defined user command\n");
+    user_input = user_input_get ();
+    switch (user_input) {
+      case 's':                /* send start streaming */
+      {
+        g_autofree gchar *cmd = NULL;
+        g_autofree gchar *response = NULL;
+        GError *error = NULL;
+        gchar *edge_id = NULL;
+        ChamgeReturn ret = CHAMGE_RETURN_OK;
+
+        edge_id = (gchar *) g_list_nth_data (context->edges, 0);
+        if (edge_id == NULL) {
+          printf ("[DUMMY] no edge is enrolled\n");
+          break;
+        }
+
+        cmd =
+            g_strdup_printf
+            ("{\"to\":\"%s\",\"method\":\"streamingStart\",\"edgeId\":\"%s\"}",
+            edge_id, edge_id);
+        printf ("[DUMMY] ==> user command : %s\n", cmd);
+        ret =
+            chamge_node_user_command (CHAMGE_NODE (context->arbiter), cmd,
+            &response, &error);
+        if (ret != CHAMGE_RETURN_OK) {
+          printf ("[DUMMY] failed to send user command >> %s\n",
+              error->message);
+        }
+      }
+        break;
+      case 't':
+      {
+        g_autofree gchar *cmd = NULL;
+        g_autofree gchar *response = NULL;
+        GError *error = NULL;
+        gchar *edge_id = NULL;
+        ChamgeReturn ret = CHAMGE_RETURN_OK;
+
+        edge_id = (gchar *) g_list_nth_data (context->edges, 0);
+        if (edge_id == NULL) {
+          printf ("[DUMMY] no edge is enrolled\n");
+          break;
+        }
+
+        cmd =
+            g_strdup_printf
+            ("{\"to\":\"%s\",\"method\":\"streamingStop\",\"edgeId\":\"%s\"}",
+            edge_id, edge_id);
+        printf ("[DUMMY] ==> user command : %s\n", cmd);
+        ret =
+            chamge_node_user_command (CHAMGE_NODE (context->arbiter), cmd,
+            &response, &error);
+        if (ret != CHAMGE_RETURN_OK) {
+          printf ("[DUMMY] failed to send user command >> %s\n",
+              error->message);
+        }
+      }
+        break;
+      case 'r':                /* send start streaming */
+      {
+        g_autofree gchar *cmd = NULL;
+        g_autofree gchar *response = NULL;
+        GError *error = NULL;
+        gchar *hub_id = NULL;
+        ChamgeReturn ret = CHAMGE_RETURN_OK;
+
+        hub_id = (gchar *) g_list_nth_data (context->hubs, 0);
+        if (hub_id == NULL) {
+          printf ("[DUMMY] no hub is enrolled\n");
+          break;
+        }
+        cmd =
+            g_strdup_printf
+            ("{\"to\":\"%s\",\"method\":\"recordingStart\",\"hubId\":\"%s\"}",
+            hub_id, hub_id);
+        printf ("[DUMMY] ==> user command : %s\n", cmd);
+        ret =
+            chamge_node_user_command (CHAMGE_NODE (context->arbiter), cmd,
+            &response, &error);
+        if (ret != CHAMGE_RETURN_OK) {
+          printf ("[DUMMY] failed to send user command >> %s\n",
+              error->message);
+        }
+      }
+        break;
+      case 'x':
+      {
+        g_autofree gchar *cmd = NULL;
+        g_autofree gchar *response = NULL;
+        GError *error = NULL;
+        gchar *hub_id = NULL;
+        ChamgeReturn ret = CHAMGE_RETURN_OK;
+
+        hub_id = (gchar *) g_list_nth_data (context->hubs, 0);
+        if (hub_id == NULL) {
+          printf ("[DUMMY] no hub is enrolled\n");
+          break;
+        }
+
+        cmd =
+            g_strdup_printf
+            ("{\"to\":\"%s\",\"method\":\"recordingStop\",\"hubId\":\"%s\"}",
+            hub_id, hub_id);
+        printf ("[DUMMY] ==> user command : %s\n", cmd);
+        ret =
+            chamge_node_user_command (CHAMGE_NODE (context->arbiter), cmd,
+            &response, &error);
+        if (ret != CHAMGE_RETURN_OK) {
+          printf ("[DUMMY] failed to send user command >> %s\n",
+              error->message);
+        }
+      }
+        break;
+      case 'h':
+        printf ("[DUMMY] s : send streaming start to first edge in the list\n");
+        printf ("[DUMMY] t : send streaming stop to first edge in the list\n");
+        printf ("[DUMMY] r : send recording start to first hub in the list\n");
+        printf ("[DUMMY] x : send recording stop to first hub in the list\n");
+        printf ("[DUMMY] q : exit\n");
+        break;
+      case 'q':
+        ret = chamge_node_deactivate (CHAMGE_NODE (context->arbiter));
+        g_assert (ret == CHAMGE_RETURN_OK);
+        quit = TRUE;
+        break;
+    }
+  }
+  g_main_loop_quit (context->loop);
+  return NULL;
+}
+
+static void
+context_setup (ArbiterContext * context)
+{
+  context->loop = g_main_loop_new (NULL, FALSE);
+}
+
+static void
+context_teardown (ArbiterContext * context)
+{
+  g_thread_join (context->user_input_thread);
+  g_main_loop_unref (context->loop);
+}
+
+void
+edge_enrolled_cb (ChamgeArbiter * arbiter, const gchar * edge_id,
+    ArbiterContext * context)
+{
+  printf ("[DUMMY] edge enroll callback >> edge_id: %s\n", edge_id);
+  context->edges = g_list_insert (context->edges, g_strdup (edge_id), 0);
+}
+
+void
+edge_delisted_cb (ChamgeArbiter * arbiter, const gchar * edge_id)
+{
+  printf ("[DUMMY] edge delisted callback >>  edge_id: %s\n", edge_id);
+}
+
+void
+hub_enrolled_cb (ChamgeArbiter * arbiter, const gchar * hub_id,
+    ArbiterContext * context)
+{
+  printf ("[DUMMY] hub enroll callback >> hub_id: %s\n", hub_id);
+  context->hubs = g_list_insert (context->hubs, g_strdup (hub_id), 0);
+}
+
+void
+hub_delisted_cb (ChamgeArbiter * arbiter, const gchar * hub_id)
+{
+  printf ("[DUMMY] hub delisted callback  >> hub_id: %s\n", hub_id);
+}
+
+int
+main (int argc, char *argv[])
+{
+  ArbiterContext context = { 0 };
+  ChamgeReturn ret = CHAMGE_RETURN_FAIL;
+  g_autofree gchar *uid =
+      g_compute_checksum_for_string (G_CHECKSUM_SHA256, DEFAULT_ARBITER_UID,
+      strlen (DEFAULT_ARBITER_UID));
+  g_autofree gchar *check_uid = NULL;
+
+  context.arbiter = chamge_arbiter_new_full (uid, DEFAULT_BACKEND);
+
+  g_object_get (context.arbiter, "uid", &check_uid, NULL);
+  g_assert_cmpstr (uid, ==, check_uid);
+
+  context_setup (&context);
+  g_signal_connect (context.arbiter, "edge-enrolled",
+      G_CALLBACK (edge_enrolled_cb), &context);
+  g_signal_connect (context.arbiter, "edge-delisted",
+      G_CALLBACK (edge_delisted_cb), &context);
+  g_signal_connect (context.arbiter, "hub-enrolled",
+      G_CALLBACK (hub_enrolled_cb), &context);
+  g_signal_connect (context.arbiter, "hub-delisted",
+      G_CALLBACK (hub_delisted_cb), &context);
+
+  ret = chamge_node_enroll (CHAMGE_NODE (context.arbiter), FALSE);
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  ret = chamge_node_activate (CHAMGE_NODE (context.arbiter));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  context.user_input_thread =
+      g_thread_new ("user-input", do_user_command, &context);
+  g_main_loop_run (context.loop);
+
+  ret = chamge_node_delist (CHAMGE_NODE (context.arbiter));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  context_teardown (&context);
+  return 1;
+
+}

--- a/examples/edge-dummy.c
+++ b/examples/edge-dummy.c
@@ -1,0 +1,108 @@
+/**
+ * examples/edge-dummy 
+ *
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Heekyoung Seo <hkseo@sk.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <chamge/chamge.h>
+
+#include <stdio.h>
+
+#include <glib.h>
+
+#define DEFAULT_EDGE_UID        "edge-987-123"
+#define DEFAULT_BACKEND         CHAMGE_BACKEND_AMQP
+
+typedef struct _EdgeContext
+{
+  ChamgeEdge *edge;
+  GMainLoop *loop;
+} EdgeContext;
+
+static void
+context_setup (EdgeContext * context)
+{
+  context->loop = g_main_loop_new (NULL, FALSE);
+}
+
+static void
+context_teardown (EdgeContext * context)
+{
+  g_main_loop_unref (context->loop);
+}
+
+static void
+state_changed_quit_cb (ChamgeEdge * edge, ChamgeNodeState state,
+    EdgeContext * context)
+{
+  g_main_loop_quit (context->loop);
+}
+
+void
+user_command_cb (ChamgeEdge * edge, const gchar * user_command,
+    gchar ** response, GError ** error)
+{
+  printf ("[DUMMY] ==> user command callback >> %s\n", user_command);
+  *response = g_strdup ("{\"result\":\"ok\"}");
+}
+
+int
+main (int argc, char *argv[])
+{
+  EdgeContext context = { 0 };
+  ChamgeNodeState state;
+  ChamgeReturn ret = CHAMGE_RETURN_FAIL;
+  g_autofree gchar *uid =
+      g_compute_checksum_for_string (G_CHECKSUM_SHA256, DEFAULT_EDGE_UID,
+      strlen (DEFAULT_EDGE_UID));
+  g_autofree gchar *check_uid = NULL;
+
+  context.edge = chamge_edge_new_full (uid, DEFAULT_BACKEND);
+
+  g_object_get (context.edge, "uid", &check_uid, NULL);
+  g_assert_cmpstr (uid, ==, check_uid);
+
+  context_setup (&context);
+  g_signal_connect (context.edge, "state-changed",
+      G_CALLBACK (state_changed_quit_cb), &context);
+  g_signal_connect (context.edge, "user-command", G_CALLBACK (user_command_cb),
+      &context);
+
+  g_object_get (context.edge, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_NULL);
+
+  ret = chamge_node_enroll (CHAMGE_NODE (context.edge), FALSE);
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_object_get (context.edge, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_ENROLLED);
+
+  ret = chamge_node_activate (CHAMGE_NODE (context.edge));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_main_loop_run (context.loop);
+
+  ret = chamge_node_delist (CHAMGE_NODE (context.edge));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_object_get (context.edge, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_NULL);
+
+  context_teardown (&context);
+
+  return 1;
+}

--- a/examples/hub-dummy.c
+++ b/examples/hub-dummy.c
@@ -1,0 +1,109 @@
+/**
+ * examples/hub-dummy 
+ *
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Jeongseok Kim <jeongseok.kim@sk.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <chamge/chamge.h>
+
+#include <stdio.h>
+
+#include <glib.h>
+
+#define DEFAULT_HUB_UID        "hub-987-123"
+#define DEFAULT_BACKEND         CHAMGE_BACKEND_AMQP
+
+typedef struct _HubContext
+{
+  ChamgeHub *hub;
+  GMainLoop *loop;
+} HubContext;
+
+static void
+context_setup (HubContext * context)
+{
+  context->loop = g_main_loop_new (NULL, FALSE);
+}
+
+static void
+context_teardown (HubContext * context)
+{
+  g_main_loop_unref (context->loop);
+}
+
+static void
+state_changed_quit_cb (ChamgeHub * hub, ChamgeNodeState state,
+    HubContext * context)
+{
+  g_main_loop_quit (context->loop);
+}
+
+void
+user_command_cb (ChamgeHub * hub, const gchar * user_command,
+    gchar ** response, GError ** error)
+{
+  printf ("[DUMMY] ==> user command callback >> %s\n", user_command);
+  *response = g_strdup ("{\"result\":\"ok\"}");
+}
+
+int
+main (int argc, char *argv[])
+{
+  HubContext context = { 0 };
+  ChamgeNodeState state;
+  ChamgeReturn ret;
+
+  g_autofree gchar *uid =
+      g_compute_checksum_for_string (G_CHECKSUM_SHA256, DEFAULT_HUB_UID,
+      strlen (DEFAULT_HUB_UID));
+  g_autofree gchar *check_uid = NULL;
+
+  context.hub = chamge_hub_new_full (uid, DEFAULT_BACKEND);
+
+  g_object_get (context.hub, "uid", &check_uid, NULL);
+  g_assert_cmpstr (uid, ==, check_uid);
+
+  context_setup (&context);
+  g_signal_connect (context.hub, "state-changed",
+      G_CALLBACK (state_changed_quit_cb), &context);
+  g_signal_connect (context.hub, "user-command", G_CALLBACK (user_command_cb),
+      &context);
+
+  g_object_get (context.hub, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_NULL);
+
+  ret = chamge_node_enroll (CHAMGE_NODE (context.hub), FALSE);
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_object_get (context.hub, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_ENROLLED);
+
+  ret = chamge_node_activate (CHAMGE_NODE (context.hub));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_main_loop_run (context.loop);
+
+  ret = chamge_node_delist (CHAMGE_NODE (context.hub));
+  g_assert (ret == CHAMGE_RETURN_OK);
+
+  g_object_get (context.hub, "state", &state, NULL);
+  g_assert (state == CHAMGE_NODE_STATE_NULL);
+
+  context_teardown (&context);
+
+  return 1;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,42 @@
+edge_dummy_source_c = [
+  'edge-dummy.c',
+]
+
+hub_dummy_source_c = [
+  'hub-dummy.c',
+]
+
+arbiter_dummy_source_c = [
+  'arbiter-dummy.c',
+]
+
+chamge_example_c_args = [
+  '-DCHAMGE_COMPILATION',
+]
+
+edge_dummy = executable (
+  'edge-dummy',
+  edge_dummy_source_c,
+  include_directories: chamge_incs,
+  c_args: [ chamge_example_c_args, '-DG_LOG_DOMAIN="CHAMGE-EDGE"' ],
+  dependencies: [ gobject_dep, gio_dep, libchamge_dbus_dep, libchamge_dep ],
+  install: true
+)
+
+hub_dummy = executable (
+  'hub-dummy',
+  hub_dummy_source_c,
+  include_directories: chamge_incs,
+  c_args: [ chamge_example_c_args, '-DG_LOG_DOMAIN="CHAMGE-HUB"' ],
+  dependencies: [ gobject_dep, gio_dep, libchamge_dbus_dep, libchamge_dep ],
+  install: true
+)
+
+arbiter_dummy = executable (
+  'arbiter-dummy',
+  arbiter_dummy_source_c,
+  include_directories: chamge_incs,
+  c_args: [ chamge_example_c_args, '-DG_LOG_DOMAIN="CHAMGE-EDGE"' ],
+  dependencies: [ gobject_dep, gio_dep, libchamge_dbus_dep, libchamge_dep ],
+  install: true
+)

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('chamge', 'c',
   license: 'Apache-2.0',
   meson_version: '>= 0.40',
   default_options: [ 'warning_level=1',
-                     'buildtype=debugoptimized' ])
+                     'buildtype=debug' ])
 
 project_version = meson.project_version()
 version_arr = project_version.split('.')
@@ -65,6 +65,7 @@ subdir('glib-compat')
 subdir('chamge')
 subdir('agent')
 subdir('tests')
+subdir('examples')
 
 if meson.version().version_compare('>= 0.46.0')
   python3 = import('python').find_installation()


### PR DESCRIPTION
- Add arbiter-dummy, edge-dummy, hub-dummy  
Examples are wait after activate and arbiter can send user command (streaming start/stop to edge, record start/stop to hub). When Edge(hub)-dummy receives user command, it prints user command body and send json message (OK). 
- Fix unused variables warning