### PR TITLE
hub: add support to send user commands

### DIFF
--- a/chamge/hub-backend.c
+++ b/chamge/hub-backend.c
@@ -230,6 +230,20 @@ chamge_hub_backend_deactivate (ChamgeHubBackend * self)
   return ret;
 }
 
+ChamgeReturn
+chamge_hub_backend_user_command_send (ChamgeHubBackend * self,
+    const gchar * cmd, gchar ** out, GError ** error)
+{
+  ChamgeHubBackendClass *klass;
+  g_return_val_if_fail (CHAMGE_IS_HUB_BACKEND (self), CHAMGE_RETURN_FAIL);
+
+  klass = CHAMGE_HUB_BACKEND_GET_CLASS (self);
+  g_return_val_if_fail (klass->user_command != NULL, CHAMGE_RETURN_FAIL);
+
+  return klass->user_command_send (self, cmd, out, error);
+}
+
+
 void
 chamge_hub_backend_set_user_command_handler (ChamgeHubBackend * self,
     ChamgeHubBackendUserCommand user_command)

--- a/chamge/hub-backend.h
+++ b/chamge/hub-backend.h
@@ -47,6 +47,11 @@ struct _ChamgeHubBackendClass
                                                  const gchar          *cmd,
                                                  gchar               **response,
                                                  GError              **error);
+
+  ChamgeReturn  (* user_command_send)          (ChamgeHubBackend      *self,
+                                                 const gchar          *cmd,
+                                                 gchar               **response,
+                                                 GError              **error);
 };
 typedef ChamgeReturn (*ChamgeHubBackendUserCommand)    (const gchar          *cmd,
                                                         gchar               **response,
@@ -62,6 +67,11 @@ ChamgeReturn            chamge_hub_backend_delist      (ChamgeHubBackend     *se
 ChamgeReturn            chamge_hub_backend_activate    (ChamgeHubBackend     *self);
 
 ChamgeReturn            chamge_hub_backend_deactivate  (ChamgeHubBackend     *self);
+
+ChamgeReturn            chamge_hub_backend_user_command_send (ChamgeHubBackend    *self,
+                                                         const gchar         *cmd,
+                                                         gchar              **out,
+                                                         GError             **error);
 
 void  chamge_hub_backend_set_user_command_handler      (ChamgeHubBackend     *self,
                                                         ChamgeHubBackendUserCommand

--- a/chamge/hub.c
+++ b/chamge/hub.c
@@ -136,6 +136,18 @@ chamge_hub_deactivate (ChamgeNode * node)
   return ret;
 }
 
+static ChamgeReturn
+chamge_hub_user_command (ChamgeNode * node, const gchar * cmd, gchar ** out,
+    GError ** error)
+{
+  ChamgeHub *self = CHAMGE_HUB (node);
+  ChamgeHubPrivate *priv = chamge_hub_get_instance_private (self);
+
+  return chamge_hub_backend_user_command_send (priv->hub_backend, cmd, out,
+      error);
+}
+
+
 static void
 chamge_hub_dispose (GObject * object)
 {
@@ -208,6 +220,7 @@ chamge_hub_class_init (ChamgeHubClass * klass)
   node_class->delist = chamge_hub_delist;
   node_class->activate = chamge_hub_activate;
   node_class->deactivate = chamge_hub_deactivate;
+  node_class->user_command = chamge_hub_user_command;
 
   klass->get_uid = chamge_hub_get_uid_default;
 }


### PR DESCRIPTION
Please check carefully this approach as I'm not sure this is the right one.
I added the support to send user commands as AMQP messages in hub, as previously the support was only for incoming ones.